### PR TITLE
feat: implement SQLite persistence for work timer data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
         "rxjs": "~7.8.0",
+        "sql.js": "^1.13.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
       },
@@ -23,6 +24,7 @@
         "@angular/cli": "^20.1.1",
         "@angular/compiler-cli": "^20.1.0",
         "@types/jasmine": "~5.1.0",
+        "@types/sql.js": "^1.4.9",
         "jasmine-core": "~5.8.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -3435,6 +3437,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.1.tgz",
+      "integrity": "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3457,6 +3466,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.9.tgz",
+      "integrity": "sha512-ep8b36RKHlgWPqjNG9ToUrPiwkhwh0AEzy883mO5Xnd+cL6VBH1EvSjBAAuxLUFF2Vn/moE3Me6v9E1Lo+48GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
@@ -8532,6 +8552,12 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
     },
     "node_modules/ssri": {
       "version": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
     "rxjs": "~7.8.0",
+    "sql.js": "^1.13.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },
@@ -35,6 +36,7 @@
     "@angular/cli": "^20.1.1",
     "@angular/compiler-cli": "^20.1.0",
     "@types/jasmine": "~5.1.0",
+    "@types/sql.js": "^1.4.9",
     "jasmine-core": "~5.8.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -7,9 +7,9 @@ import { routes } from './app.routes';
 import { WORK_SESSION_REPOSITORY, WORK_DAY_REPOSITORY, TIMER_STATE_REPOSITORY } from './domain/repositories/injection-tokens';
 
 // Repository implementations
-import { LocalStorageWorkSessionRepository } from './infrastructure/repositories/local-storage-work-session.repository';
-import { LocalStorageWorkDayRepository } from './infrastructure/repositories/local-storage-work-day.repository';
-import { LocalStorageTimerStateRepository } from './infrastructure/repositories/local-storage-timer-state.repository';
+import { SqliteWorkSessionRepository } from './infrastructure/repositories/sqlite-work-session.repository';
+import { SqliteWorkDayRepository } from './infrastructure/repositories/sqlite-work-day.repository';
+import { SqliteTimerStateRepository } from './infrastructure/repositories/sqlite-timer-state.repository';
 
 // Adapter injection tokens
 import { TIMER_ADAPTER, DATE_TIME_ADAPTER, STORAGE_ADAPTER } from './infrastructure/adapters/injection-tokens';
@@ -26,9 +26,9 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     
     // Repository providers
-    { provide: WORK_SESSION_REPOSITORY, useClass: LocalStorageWorkSessionRepository },
-    { provide: WORK_DAY_REPOSITORY, useClass: LocalStorageWorkDayRepository },
-    { provide: TIMER_STATE_REPOSITORY, useClass: LocalStorageTimerStateRepository },
+    { provide: WORK_SESSION_REPOSITORY, useClass: SqliteWorkSessionRepository },
+    { provide: WORK_DAY_REPOSITORY, useClass: SqliteWorkDayRepository },
+    { provide: TIMER_STATE_REPOSITORY, useClass: SqliteTimerStateRepository },
     
     // Adapter providers
     { provide: TIMER_ADAPTER, useClass: SystemTimerAdapter },

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -20,3 +20,61 @@ app-root {
   min-height: 100vh;
   padding: 20px 0;
 }
+
+/* Initialization states */
+.initialization-loading,
+.initialization-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 2rem;
+}
+
+.initialization-loading h2,
+.initialization-error h2 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.initialization-loading p,
+.initialization-error p {
+  color: #7f8c8d;
+  margin-bottom: 2rem;
+  font-size: 1.1rem;
+}
+
+.initialization-error button {
+  background: #3498db;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.initialization-error button:hover {
+  background: #2980b9;
+}
+
+/* Loading spinner */
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #ecf0f1;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,3 +1,16 @@
-<app-dashboard-container></app-dashboard-container>
-
-<router-outlet />
+@if (initializationError()) {
+  <div class="initialization-error">
+    <h2>Initialization Error</h2>
+    <p>Failed to initialize the application: {{ initializationError() }}</p>
+    <button onclick="window.location.reload()">Retry</button>
+  </div>
+} @else if (!isInitialized()) {
+  <div class="initialization-loading">
+    <h2>Initializing Work Timer</h2>
+    <p>Setting up database and migrating data...</p>
+    <div class="loading-spinner"></div>
+  </div>
+} @else {
+  <app-dashboard-container></app-dashboard-container>
+  <router-outlet />
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,9 +3,11 @@
  * @author Work Timer Application
  */
 
-import { Component, signal } from '@angular/core';
+import { Component, signal, inject, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import { DashboardContainer } from './presentation/containers/dashboard/dashboard.container';
+import { AppInitializationService } from './infrastructure/services/app-initialization.service';
 
 /**
  * Root application component that hosts the main dashboard.
@@ -14,11 +16,32 @@ import { DashboardContainer } from './presentation/containers/dashboard/dashboar
  */
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, DashboardContainer],
+  imports: [RouterOutlet, DashboardContainer, CommonModule],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
-export class App {
+export class App implements OnInit {
   /** Application title signal */
   protected readonly title = signal('work_timer');
+  
+  /** Initialization status signal */
+  protected readonly isInitialized = signal(false);
+  
+  /** Initialization error signal */
+  protected readonly initializationError = signal<string | null>(null);
+  
+  /** Injected initialization service */
+  private readonly initializationService = inject(AppInitializationService);
+
+  async ngOnInit(): Promise<void> {
+    try {
+      await this.initializationService.initialize();
+      this.isInitialized.set(true);
+    } catch (error) {
+      console.error('Failed to initialize app:', error);
+      this.initializationError.set(
+        error instanceof Error ? error.message : 'Unknown initialization error'
+      );
+    }
+  }
 }

--- a/src/app/infrastructure/index.ts
+++ b/src/app/infrastructure/index.ts
@@ -7,6 +7,13 @@
 export * from './repositories/local-storage-work-session.repository';
 export * from './repositories/local-storage-work-day.repository';
 export * from './repositories/local-storage-timer-state.repository';
+export * from './repositories/sqlite-work-session.repository';
+export * from './repositories/sqlite-work-day.repository';
+export * from './repositories/sqlite-timer-state.repository';
+
+// Services
+export * from './services/sqlite-database.service';
+export * from './services/app-initialization.service';
 
 // Adapters
 export * from './adapters/timer.adapter';

--- a/src/app/infrastructure/repositories/sqlite-timer-state.repository.ts
+++ b/src/app/infrastructure/repositories/sqlite-timer-state.repository.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview SQLite implementation of TimerStateRepository.
+ * @author Work Timer Application
+ */
+
+import { Injectable } from '@angular/core';
+import { TimerStatus, WorkDayDate } from '../../domain/index';
+import { TimerStateRepository, TimerStateData } from '../../domain/repositories/timer-state.repository';
+import { SqliteDatabaseService } from '../services/sqlite-database.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SqliteTimerStateRepository implements TimerStateRepository {
+  
+  constructor(private databaseService: SqliteDatabaseService) {}
+
+  async saveCurrentState(state: TimerStateData): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const now = new Date().toISOString();
+      
+      db.run(`
+        INSERT OR REPLACE INTO timer_state (id, current_work_date, status, current_session_start_time, current_session_time, last_updated)
+        VALUES ('default', ?, ?, ?, ?, ?)
+      `, [
+        state.date.toISOString(),
+        state.status.value,
+        state.currentSessionStartTime?.toISOString() || null,
+        state.currentSessionTime,
+        now
+      ]);
+
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error saving timer state to SQLite:', error);
+      throw error;
+    }
+  }
+
+  async loadCurrentState(): Promise<TimerStateData | null> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const result = db.exec(`
+        SELECT current_work_date, status, current_session_start_time, current_session_time
+        FROM timer_state 
+        WHERE id = 'default'
+      `);
+
+      if (!result.length || !result[0].values.length) {
+        return null;
+      }
+
+      const row = result[0].values[0];
+      
+      if (!row[0]) { // No current work date
+        return null;
+      }
+
+      return {
+        date: WorkDayDate.fromString(row[0] as string),
+        status: TimerStatus.fromString(row[1] as string),
+        currentSessionStartTime: row[2] ? new Date(row[2] as string) : undefined,
+        currentSessionTime: row[3] as number
+      };
+    } catch (error) {
+      console.error('Error loading timer state from SQLite:', error);
+      return null;
+    }
+  }
+
+  async clearCurrentState(): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const now = new Date().toISOString();
+      
+      db.run(`
+        UPDATE timer_state 
+        SET current_work_date = NULL, 
+            status = 'STOPPED', 
+            current_session_start_time = NULL, 
+            current_session_time = 0,
+            last_updated = ?
+        WHERE id = 'default'
+      `, [now]);
+
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error clearing timer state from SQLite:', error);
+      throw error;
+    }
+  }
+
+  async hasActiveSession(): Promise<boolean> {
+    const state = await this.loadCurrentState();
+    return state !== null && state.status.isRunning();
+  }
+}

--- a/src/app/infrastructure/repositories/sqlite-work-day.repository.ts
+++ b/src/app/infrastructure/repositories/sqlite-work-day.repository.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview SQLite implementation of WorkDayRepository.
+ * @author Work Timer Application
+ */
+
+import { Injectable } from '@angular/core';
+import { WorkDay, WorkDayDate } from '../../domain/index';
+import { WorkDayRepository } from '../../domain/repositories/work-day.repository';
+import { SqliteDatabaseService } from '../services/sqlite-database.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SqliteWorkDayRepository implements WorkDayRepository {
+  
+  constructor(private databaseService: SqliteDatabaseService) {}
+
+  async save(workDay: WorkDay): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const now = new Date().toISOString();
+      const workDayData = workDay.toData();
+      
+      // Save work day
+      db.run(`
+        INSERT OR REPLACE INTO work_days (date, status, pause_deduction_applied, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `, [
+        workDayData.date,
+        workDayData.status,
+        workDayData.pauseDeductionApplied ? 1 : 0,
+        now,
+        now
+      ]);
+
+      // Save completed sessions
+      for (const sessionData of workDayData.sessions) {
+        db.run(`
+          INSERT OR REPLACE INTO work_sessions (id, work_date, start_time, end_time, duration, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `, [
+          sessionData.id,
+          sessionData.date,
+          sessionData.startTime,
+          sessionData.endTime,
+          sessionData.duration,
+          now,
+          now
+        ]);
+      }
+
+      // Handle current session if exists
+      if (workDayData.currentSession) {
+        db.run(`
+          INSERT OR REPLACE INTO work_sessions (id, work_date, start_time, end_time, duration, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `, [
+          workDayData.currentSession.id,
+          workDayData.currentSession.date,
+          workDayData.currentSession.startTime,
+          workDayData.currentSession.endTime,
+          workDayData.currentSession.duration,
+          now,
+          now
+        ]);
+      }
+
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error saving work day to SQLite:', error);
+      throw error;
+    }
+  }
+
+  async findByDate(date: WorkDayDate): Promise<WorkDay | null> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const dateString = date.toISOString();
+      
+      // Get work day data
+      const workDayResult = db.exec(`
+        SELECT date, status, pause_deduction_applied
+        FROM work_days 
+        WHERE date = ?
+      `, [dateString]);
+
+      if (!workDayResult.length || !workDayResult[0].values.length) {
+        return null;
+      }
+
+      const workDayRow = workDayResult[0].values[0];
+      
+      // Get sessions for this work day
+      const sessionsResult = db.exec(`
+        SELECT id, work_date, start_time, end_time, duration
+        FROM work_sessions 
+        WHERE work_date = ?
+        ORDER BY start_time ASC
+      `, [dateString]);
+
+      const sessions = sessionsResult.length > 0 ? 
+        sessionsResult[0].values.map(row => ({
+          id: row[0] as string,
+          date: row[1] as string,
+          startTime: row[2] as string,
+          endTime: row[3] as string | null,
+          duration: row[4] as number
+        })) : [];
+
+      // Separate completed sessions from current session (if any)
+      const completedSessions = sessions.filter(s => s.endTime !== null);
+      const currentSession = sessions.find(s => s.endTime === null) || null;
+
+      const workDayData = {
+        date: workDayRow[0] as string,
+        status: workDayRow[1] as string,
+        pauseDeductionApplied: (workDayRow[2] as number) === 1,
+        sessions: completedSessions,
+        currentSession
+      };
+
+      return WorkDay.fromData(workDayData);
+    } catch (error) {
+      console.error('Error finding work day by date from SQLite:', error);
+      return null;
+    }
+  }
+
+  async findAll(): Promise<WorkDay[]> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      // Get all work days
+      const workDaysResult = db.exec(`
+        SELECT date, status, pause_deduction_applied
+        FROM work_days 
+        ORDER BY date DESC
+      `);
+
+      if (!workDaysResult.length) {
+        return [];
+      }
+
+      const workDays: WorkDay[] = [];
+      
+      for (const row of workDaysResult[0].values) {
+        const dateString = row[0] as string;
+        
+        // Get sessions for this work day
+        const sessionsResult = db.exec(`
+          SELECT id, work_date, start_time, end_time, duration
+          FROM work_sessions 
+          WHERE work_date = ?
+          ORDER BY start_time ASC
+        `, [dateString]);
+
+        const sessions = sessionsResult.length > 0 ? 
+          sessionsResult[0].values.map(sessionRow => ({
+            id: sessionRow[0] as string,
+            date: sessionRow[1] as string,
+            startTime: sessionRow[2] as string,
+            endTime: sessionRow[3] as string | null,
+            duration: sessionRow[4] as number
+          })) : [];
+
+        // Separate completed sessions from current session
+        const completedSessions = sessions.filter(s => s.endTime !== null);
+        const currentSession = sessions.find(s => s.endTime === null) || null;
+
+        const workDayData = {
+          date: row[0] as string,
+          status: row[1] as string,
+          pauseDeductionApplied: (row[2] as number) === 1,
+          sessions: completedSessions,
+          currentSession
+        };
+
+        workDays.push(WorkDay.fromData(workDayData));
+      }
+
+      return workDays;
+    } catch (error) {
+      console.error('Error finding all work days from SQLite:', error);
+      return [];
+    }
+  }
+
+  async delete(date: WorkDayDate): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const dateString = date.toISOString();
+      
+      // Delete sessions first (due to foreign key constraint)
+      db.run(`DELETE FROM work_sessions WHERE work_date = ?`, [dateString]);
+      
+      // Delete work day
+      db.run(`DELETE FROM work_days WHERE date = ?`, [dateString]);
+      
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error deleting work day from SQLite:', error);
+      throw error;
+    }
+  }
+
+  async exists(date: WorkDayDate): Promise<boolean> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const result = db.exec(`
+        SELECT COUNT(*) as count 
+        FROM work_days 
+        WHERE date = ?
+      `, [date.toISOString()]);
+
+      return result.length > 0 && result[0].values.length > 0 && result[0].values[0][0] > 0;
+    } catch (error) {
+      console.error('Error checking if work day exists in SQLite:', error);
+      return false;
+    }
+  }
+}

--- a/src/app/infrastructure/repositories/sqlite-work-session.repository.ts
+++ b/src/app/infrastructure/repositories/sqlite-work-session.repository.ts
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview SQLite implementation of WorkSessionRepository.
+ * @author Work Timer Application
+ */
+
+import { Injectable } from '@angular/core';
+import { WorkSession, WorkDayDate } from '../../domain/index';
+import { WorkSessionRepository } from '../../domain/repositories/work-session.repository';
+import { SqliteDatabaseService } from '../services/sqlite-database.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SqliteWorkSessionRepository implements WorkSessionRepository {
+  
+  constructor(private databaseService: SqliteDatabaseService) {}
+
+  async save(session: WorkSession): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const now = new Date().toISOString();
+      const sessionData = session.toData();
+      
+      db.run(`
+        INSERT OR REPLACE INTO work_sessions (id, work_date, start_time, end_time, duration, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [
+        sessionData.id,
+        sessionData.date,
+        sessionData.startTime.toISOString(),
+        sessionData.endTime?.toISOString() || null,
+        sessionData.duration,
+        now,
+        now
+      ]);
+
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error saving work session to SQLite:', error);
+      throw error;
+    }
+  }
+
+  async findById(id: string): Promise<WorkSession | null> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const result = db.exec(`
+        SELECT id, work_date, start_time, end_time, duration
+        FROM work_sessions 
+        WHERE id = ?
+      `, [id]);
+
+      if (!result.length || !result[0].values.length) {
+        return null;
+      }
+
+      const row = result[0].values[0];
+      const sessionData = {
+        id: row[0] as string,
+        date: row[1] as string,
+        startTime: new Date(row[2] as string),
+        endTime: row[3] ? new Date(row[3] as string) : null,
+        duration: row[4] as number
+      };
+
+      return WorkSession.fromData(sessionData);
+    } catch (error) {
+      console.error('Error finding work session by id from SQLite:', error);
+      return null;
+    }
+  }
+
+  async findByDate(date: WorkDayDate): Promise<WorkSession[]> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const result = db.exec(`
+        SELECT id, work_date, start_time, end_time, duration
+        FROM work_sessions 
+        WHERE work_date = ?
+        ORDER BY start_time ASC
+      `, [date.toISOString()]);
+
+      if (!result.length) {
+        return [];
+      }
+
+      return result[0].values.map(row => {
+        const sessionData = {
+          id: row[0] as string,
+          date: row[1] as string,
+          startTime: new Date(row[2] as string),
+          endTime: row[3] ? new Date(row[3] as string) : null,
+          duration: row[4] as number
+        };
+
+        return WorkSession.fromData(sessionData);
+      });
+    } catch (error) {
+      console.error('Error finding work sessions by date from SQLite:', error);
+      return [];
+    }
+  }
+
+  async findAll(): Promise<WorkSession[]> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      const result = db.exec(`
+        SELECT id, work_date, start_time, end_time, duration
+        FROM work_sessions 
+        ORDER BY work_date DESC, start_time ASC
+      `);
+
+      if (!result.length) {
+        return [];
+      }
+
+      return result[0].values.map(row => {
+        const sessionData = {
+          id: row[0] as string,
+          date: row[1] as string,
+          startTime: new Date(row[2] as string),
+          endTime: row[3] ? new Date(row[3] as string) : null,
+          duration: row[4] as number
+        };
+
+        return WorkSession.fromData(sessionData);
+      });
+    } catch (error) {
+      console.error('Error finding all work sessions from SQLite:', error);
+      return [];
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      db.run(`DELETE FROM work_sessions WHERE id = ?`, [id]);
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error deleting work session from SQLite:', error);
+      throw error;
+    }
+  }
+
+  async deleteByDate(date: WorkDayDate): Promise<void> {
+    await this.databaseService.initialize();
+    const db = this.databaseService.getDatabase();
+    
+    try {
+      db.run(`DELETE FROM work_sessions WHERE work_date = ?`, [date.toISOString()]);
+      await this.databaseService.saveToStorage();
+    } catch (error) {
+      console.error('Error deleting work sessions by date from SQLite:', error);
+      throw error;
+    }
+  }
+}

--- a/src/app/infrastructure/services/app-initialization.service.ts
+++ b/src/app/infrastructure/services/app-initialization.service.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview App initialization service for setting up database and migrating data.
+ * @author Work Timer Application
+ */
+
+import { Injectable } from '@angular/core';
+import { SqliteDatabaseService } from './sqlite-database.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppInitializationService {
+  private isInitialized = false;
+
+  constructor(private databaseService: SqliteDatabaseService) {}
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      return;
+    }
+
+    try {
+      console.log('Initializing SQLite database...');
+      await this.databaseService.initialize();
+      
+      console.log('Migrating data from localStorage...');
+      await this.databaseService.migrateFromLocalStorage();
+      
+      this.isInitialized = true;
+      console.log('App initialization completed successfully');
+    } catch (error) {
+      console.error('Failed to initialize app:', error);
+      throw error;
+    }
+  }
+
+  getInitializationStatus(): boolean {
+    return this.isInitialized;
+  }
+}

--- a/src/app/infrastructure/services/sqlite-database.service.ts
+++ b/src/app/infrastructure/services/sqlite-database.service.ts
@@ -1,0 +1,198 @@
+/**
+ * @fileoverview SQLite database service for managing database initialization and connections.
+ * @author Work Timer Application
+ */
+
+import { Injectable } from '@angular/core';
+import initSqlJs, { Database } from 'sql.js';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SqliteDatabaseService {
+  private database: Database | null = null;
+  private isInitialized = false;
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      return;
+    }
+
+    try {
+      const SQL = await initSqlJs({
+        locateFile: file => `https://sql.js.org/dist/${file}`
+      });
+
+      const existingData = localStorage.getItem('work-timer-sqlite-db');
+      if (existingData) {
+        const data = new Uint8Array(JSON.parse(existingData));
+        this.database = new SQL.Database(data);
+      } else {
+        this.database = new SQL.Database();
+        await this.createTables();
+      }
+
+      this.isInitialized = true;
+    } catch (error) {
+      console.error('Failed to initialize SQLite database:', error);
+      throw error;
+    }
+  }
+
+  getDatabase(): Database {
+    if (!this.database) {
+      throw new Error('Database not initialized. Call initialize() first.');
+    }
+    return this.database;
+  }
+
+  async saveToStorage(): Promise<void> {
+    if (!this.database) {
+      return;
+    }
+
+    try {
+      const data = this.database.export();
+      localStorage.setItem('work-timer-sqlite-db', JSON.stringify(Array.from(data)));
+    } catch (error) {
+      console.error('Failed to save database to localStorage:', error);
+    }
+  }
+
+  private async createTables(): Promise<void> {
+    if (!this.database) {
+      return;
+    }
+
+    const createWorkDaysTable = `
+      CREATE TABLE IF NOT EXISTS work_days (
+        date TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        pause_deduction_applied INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `;
+
+    const createWorkSessionsTable = `
+      CREATE TABLE IF NOT EXISTS work_sessions (
+        id TEXT PRIMARY KEY,
+        work_date TEXT NOT NULL,
+        start_time TEXT NOT NULL,
+        end_time TEXT,
+        duration INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY (work_date) REFERENCES work_days (date)
+      )
+    `;
+
+    const createTimerStateTable = `
+      CREATE TABLE IF NOT EXISTS timer_state (
+        id TEXT PRIMARY KEY,
+        current_work_date TEXT,
+        status TEXT NOT NULL,
+        current_session_start_time TEXT,
+        current_session_time INTEGER DEFAULT 0,
+        last_updated TEXT NOT NULL
+      )
+    `;
+
+    try {
+      this.database.run(createWorkDaysTable);
+      this.database.run(createWorkSessionsTable);
+      this.database.run(createTimerStateTable);
+      
+      // Insert default timer state if it doesn't exist
+      this.database.run(`
+        INSERT OR IGNORE INTO timer_state (id, status, last_updated)
+        VALUES ('default', 'STOPPED', datetime('now'))
+      `);
+
+      await this.saveToStorage();
+    } catch (error) {
+      console.error('Failed to create database tables:', error);
+      throw error;
+    }
+  }
+
+  async migrateFromLocalStorage(): Promise<void> {
+    if (!this.database) {
+      return;
+    }
+
+    try {
+      // Check if migration has already been done
+      const migrationCheck = this.database.exec(`
+        SELECT COUNT(*) as count FROM work_days
+      `);
+      
+      if (migrationCheck.length > 0 && migrationCheck[0].values[0][0] > 0) {
+        return; // Already migrated
+      }
+
+      // Migrate work days from localStorage
+      const workDaysData = localStorage.getItem('work-timer-workdays');
+      if (workDaysData) {
+        const workDays = JSON.parse(workDaysData);
+        for (const workDayData of workDays) {
+          const now = new Date().toISOString();
+          this.database.run(`
+            INSERT OR REPLACE INTO work_days (date, status, pause_deduction_applied, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+          `, [
+            workDayData.date,
+            workDayData.status || 'STOPPED',
+            workDayData.pauseDeductionApplied ? 1 : 0,
+            now,
+            now
+          ]);
+
+          // Migrate sessions for this work day
+          if (workDayData.sessions) {
+            for (const sessionData of workDayData.sessions) {
+              this.database.run(`
+                INSERT OR REPLACE INTO work_sessions (id, work_date, start_time, end_time, duration, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+              `, [
+                sessionData.id,
+                sessionData.date,
+                sessionData.startTime,
+                sessionData.endTime,
+                sessionData.duration,
+                now,
+                now
+              ]);
+            }
+          }
+        }
+      }
+
+      // Migrate work sessions from localStorage
+      const sessionsData = localStorage.getItem('work-timer-sessions');
+      if (sessionsData) {
+        const sessions = JSON.parse(sessionsData);
+        for (const sessionData of sessions) {
+          const now = new Date().toISOString();
+          this.database.run(`
+            INSERT OR IGNORE INTO work_sessions (id, work_date, start_time, end_time, duration, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+          `, [
+            sessionData.id,
+            sessionData.date,
+            sessionData.startTime,
+            sessionData.endTime,
+            sessionData.duration,
+            now,
+            now
+          ]);
+        }
+      }
+
+      await this.saveToStorage();
+      console.log('Successfully migrated data from localStorage to SQLite');
+    } catch (error) {
+      console.error('Failed to migrate from localStorage:', error);
+    }
+  }
+}

--- a/src/app/presentation/components/work-history/work-history.component.css
+++ b/src/app/presentation/components/work-history/work-history.component.css
@@ -1,0 +1,245 @@
+.work-history {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+  padding-bottom: 15px;
+  border-bottom: 2px solid #ecf0f1;
+}
+
+.history-header h2 {
+  margin: 0;
+  color: #2c3e50;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.refresh-btn {
+  background: #3498db;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: #2980b9;
+}
+
+.refresh-btn:disabled {
+  background: #bdc3c7;
+  cursor: not-allowed;
+}
+
+.error-message {
+  background: #e74c3c;
+  color: white;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.error-message button {
+  background: white;
+  color: #e74c3c;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.no-data {
+  text-align: center;
+  padding: 40px 20px;
+  color: #7f8c8d;
+  font-size: 1.1rem;
+}
+
+.history-entry {
+  margin-bottom: 25px;
+  border: 1px solid #ecf0f1;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.entry-header {
+  background: #f8f9fa;
+  padding: 15px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.entry-header h3 {
+  margin: 0;
+  color: #2c3e50;
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.entry-summary {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+}
+
+.total-time {
+  background: #3498db;
+  color: white;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.session-count {
+  color: #7f8c8d;
+  font-size: 0.9rem;
+}
+
+.sessions-list {
+  padding: 0;
+}
+
+.session-item {
+  padding: 15px 20px;
+  border-bottom: 1px solid #f8f9fa;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.session-item:last-child {
+  border-bottom: none;
+}
+
+.session-info {
+  flex: 1;
+}
+
+.session-time {
+  display: block;
+  color: #2c3e50;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.session-duration {
+  color: #7f8c8d;
+  font-size: 0.9rem;
+}
+
+.session-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.session-edit {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.time-input {
+  padding: 6px 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.edit-btn, .delete-btn, .save-btn, .cancel-btn {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: background-color 0.2s;
+}
+
+.edit-btn {
+  background: #f39c12;
+  color: white;
+}
+
+.edit-btn:hover {
+  background: #e67e22;
+}
+
+.delete-btn {
+  background: #e74c3c;
+  color: white;
+}
+
+.delete-btn:hover {
+  background: #c0392b;
+}
+
+.save-btn {
+  background: #27ae60;
+  color: white;
+}
+
+.save-btn:hover {
+  background: #229954;
+}
+
+.cancel-btn {
+  background: #95a5a6;
+  color: white;
+}
+
+.cancel-btn:hover {
+  background: #7f8c8d;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .work-history {
+    margin: 10px;
+    padding: 15px;
+  }
+  
+  .history-header {
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+    text-align: center;
+  }
+  
+  .entry-header {
+    flex-direction: column;
+    gap: 10px;
+    align-items: stretch;
+    text-align: center;
+  }
+  
+  .session-item {
+    flex-direction: column;
+    gap: 10px;
+    align-items: stretch;
+  }
+  
+  .session-edit {
+    flex-direction: column;
+  }
+  
+  .session-actions {
+    justify-content: center;
+  }
+}

--- a/src/app/presentation/components/work-history/work-history.component.ts
+++ b/src/app/presentation/components/work-history/work-history.component.ts
@@ -1,0 +1,269 @@
+/**
+ * @fileoverview Work history component for displaying past work sessions.
+ * @author Work Timer Application
+ */
+
+import { Component, signal, computed, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { WorkSession, WorkDay, WorkDayDate } from '../../../domain/index';
+import { WorkDayRepository } from '../../../domain/repositories/work-day.repository';
+import { WorkSessionRepository } from '../../../domain/repositories/work-session.repository';
+import { WORK_DAY_REPOSITORY, WORK_SESSION_REPOSITORY } from '../../../domain/repositories/injection-tokens';
+
+interface WorkHistoryEntry {
+  date: string;
+  workDay: WorkDay;
+  sessions: WorkSession[];
+  totalWorkTime: string;
+  effectiveWorkTime: string;
+  sessionCount: number;
+}
+
+@Component({
+  selector: 'app-work-history',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="work-history">
+      <div class="history-header">
+        <h2>Work History</h2>
+        <button 
+          class="refresh-btn" 
+          (click)="loadHistory()"
+          [disabled]="isLoading()">
+          @if (isLoading()) {
+            Loading...
+          } @else {
+            Refresh
+          }
+        </button>
+      </div>
+
+      @if (error()) {
+        <div class="error-message">
+          <p>Error loading work history: {{ error() }}</p>
+          <button (click)="loadHistory()">Retry</button>
+        </div>
+      }
+
+      @if (historyEntries().length === 0 && !isLoading() && !error()) {
+        <div class="no-data">
+          <p>No work history found. Start working to see your progress here!</p>
+        </div>
+      }
+
+      @for (entry of historyEntries(); track entry.date) {
+        <div class="history-entry">
+          <div class="entry-header">
+            <h3>{{ formatDate(entry.date) }}</h3>
+            <div class="entry-summary">
+              <span class="total-time">{{ entry.totalWorkTime }}</span>
+              <span class="session-count">{{ entry.sessionCount }} session{{ entry.sessionCount !== 1 ? 's' : '' }}</span>
+            </div>
+          </div>
+          
+          <div class="sessions-list">
+            @for (session of entry.sessions; track session.id) {
+              <div class="session-item">
+                <div class="session-info">
+                  <span class="session-time">
+                    {{ formatTime(session.startTime) }} - 
+                    {{ session.endTime ? formatTime(session.endTime) : 'In progress' }}
+                  </span>
+                  <span class="session-duration">
+                    {{ formatDuration(session.duration.milliseconds) }}
+                  </span>
+                </div>
+                @if (editingSession() === session.id) {
+                  <div class="session-edit">
+                    <input 
+                      type="datetime-local" 
+                      [(ngModel)]="editStartTime"
+                      class="time-input">
+                    <input 
+                      type="datetime-local" 
+                      [(ngModel)]="editEndTime"
+                      class="time-input">
+                    <button (click)="saveSessionEdit(session)" class="save-btn">Save</button>
+                    <button (click)="cancelEdit()" class="cancel-btn">Cancel</button>
+                  </div>
+                } @else {
+                  <div class="session-actions">
+                    <button (click)="startEditSession(session)" class="edit-btn">Edit</button>
+                    <button (click)="deleteSession(session)" class="delete-btn">Delete</button>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styleUrl: './work-history.component.css'
+})
+export class WorkHistoryComponent implements OnInit {
+  private workDayRepository = inject(WORK_DAY_REPOSITORY);
+  private workSessionRepository = inject(WORK_SESSION_REPOSITORY);
+
+  private readonly _historyEntries = signal<WorkHistoryEntry[]>([]);
+  private readonly _isLoading = signal(false);
+  private readonly _error = signal<string | null>(null);
+  private readonly _editingSession = signal<string | null>(null);
+
+  editStartTime = '';
+  editEndTime = '';
+
+  readonly historyEntries = computed(() => this._historyEntries());
+  readonly isLoading = computed(() => this._isLoading());
+  readonly error = computed(() => this._error());
+  readonly editingSession = computed(() => this._editingSession());
+
+  async ngOnInit(): Promise<void> {
+    await this.loadHistory();
+  }
+
+  async loadHistory(): Promise<void> {
+    this._isLoading.set(true);
+    this._error.set(null);
+
+    try {
+      const workDays = await this.workDayRepository.findAll();
+      const entries: WorkHistoryEntry[] = [];
+
+      for (const workDay of workDays) {
+        if (workDay.hasActivity()) {
+          const sessions = await this.workSessionRepository.findByDate(workDay.date);
+          const completedSessions = sessions.filter(s => s.isCompleted);
+          
+          const totalWorkTime = workDay.calculateTotalWorkTime();
+          const effectiveWorkTime = this.calculateEffectiveWorkTime(workDay);
+
+          entries.push({
+            date: workDay.date.toISOString(),
+            workDay,
+            sessions: completedSessions,
+            totalWorkTime: this.formatDuration(totalWorkTime.milliseconds),
+            effectiveWorkTime: this.formatDuration(effectiveWorkTime.milliseconds),
+            sessionCount: completedSessions.length
+          });
+        }
+      }
+
+      // Sort by date descending (most recent first)
+      entries.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+      
+      this._historyEntries.set(entries);
+    } catch (error) {
+      console.error('Error loading work history:', error);
+      this._error.set(error instanceof Error ? error.message : 'Unknown error');
+    } finally {
+      this._isLoading.set(false);
+    }
+  }
+
+  startEditSession(session: WorkSession): void {
+    this._editingSession.set(session.id);
+    this.editStartTime = this.formatDateTimeLocal(session.startTime);
+    this.editEndTime = session.endTime ? this.formatDateTimeLocal(session.endTime) : '';
+  }
+
+  async saveSessionEdit(session: WorkSession): Promise<void> {
+    try {
+      const startTime = new Date(this.editStartTime);
+      const endTime = this.editEndTime ? new Date(this.editEndTime) : null;
+
+      if (!endTime) {
+        alert('End time is required for completed sessions');
+        return;
+      }
+
+      if (startTime >= endTime) {
+        alert('Start time must be before end time');
+        return;
+      }
+
+      // Create updated session
+      const updatedSession = session.stop(endTime);
+      const newSession = WorkSession.fromData({
+        id: session.id,
+        startTime,
+        endTime,
+        duration: endTime.getTime() - startTime.getTime(),
+        date: session.workDate.toISOString()
+      });
+
+      await this.workSessionRepository.save(newSession);
+      await this.loadHistory();
+      this.cancelEdit();
+      
+    } catch (error) {
+      console.error('Error saving session edit:', error);
+      alert('Failed to save changes: ' + (error instanceof Error ? error.message : 'Unknown error'));
+    }
+  }
+
+  cancelEdit(): void {
+    this._editingSession.set(null);
+    this.editStartTime = '';
+    this.editEndTime = '';
+  }
+
+  async deleteSession(session: WorkSession): Promise<void> {
+    if (!confirm('Are you sure you want to delete this work session?')) {
+      return;
+    }
+
+    try {
+      await this.workSessionRepository.delete(session.id);
+      await this.loadHistory();
+    } catch (error) {
+      console.error('Error deleting session:', error);
+      alert('Failed to delete session: ' + (error instanceof Error ? error.message : 'Unknown error'));
+    }
+  }
+
+  private calculateEffectiveWorkTime(workDay: WorkDay): any {
+    const totalWorkTime = workDay.calculateTotalWorkTime();
+    // Simplified calculation - in real implementation, apply pause deduction logic
+    return totalWorkTime;
+  }
+
+  formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  }
+
+  formatTime(date: Date): string {
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  formatDuration(milliseconds: number): string {
+    const totalSeconds = Math.floor(milliseconds / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m ${seconds}s`;
+    } else if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    } else {
+      return `${seconds}s`;
+    }
+  }
+
+  private formatDateTimeLocal(date: Date): string {
+    const offset = date.getTimezoneOffset();
+    const localDate = new Date(date.getTime() - (offset * 60 * 1000));
+    return localDate.toISOString().slice(0, 16);
+  }
+}

--- a/src/app/presentation/containers/dashboard/dashboard.container.css
+++ b/src/app/presentation/containers/dashboard/dashboard.container.css
@@ -12,3 +12,54 @@
   flex-direction: column;
   gap: var(--spacing-2xl);
 }
+
+/* Navigation tabs */
+.navigation-tabs {
+  display: flex;
+  margin: 20px 0;
+  border-bottom: 2px solid #ecf0f1;
+  background: white;
+  border-radius: 8px 8px 0 0;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.nav-tab {
+  flex: 1;
+  background: #f8f9fa;
+  border: none;
+  padding: 15px 20px;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #7f8c8d;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-bottom: 3px solid transparent;
+}
+
+.nav-tab:hover {
+  background: #e9ecef;
+  color: #2c3e50;
+}
+
+.nav-tab.active {
+  background: white;
+  color: #3498db;
+  border-bottom-color: #3498db;
+}
+
+.nav-tab:first-child {
+  border-right: 1px solid #ecf0f1;
+}
+
+/* Responsive design for tabs */
+@media (max-width: 768px) {
+  .navigation-tabs {
+    margin: 10px 0;
+  }
+  
+  .nav-tab {
+    padding: 12px 15px;
+    font-size: 0.9rem;
+  }
+}

--- a/src/app/presentation/containers/dashboard/dashboard.container.html
+++ b/src/app/presentation/containers/dashboard/dashboard.container.html
@@ -7,24 +7,45 @@
   <!-- Header Section -->
   <app-header [data]="headerData()" />
 
+  <!-- Navigation Tabs -->
+  <div class="navigation-tabs">
+    <button 
+      class="nav-tab"
+      [class.active]="currentView() === 'timer'"
+      (click)="showTimerView()">
+      Timer
+    </button>
+    <button 
+      class="nav-tab"
+      [class.active]="currentView() === 'history'"
+      (click)="showHistoryView()">
+      Work History
+    </button>
+  </div>
+
   <!-- Main Content Area -->
   <div class="main-content flex flex-column gap-2xl">
-    <!-- Timer Controls -->
-    <app-timer-controls 
-      [data]="controlsData()" 
-      (startStopClicked)="onStartStopClick()"
-      (resetClicked)="onResetClick()" />
+    @if (currentView() === 'timer') {
+      <!-- Timer Controls -->
+      <app-timer-controls 
+        [data]="controlsData()" 
+        (startStopClicked)="onStartStopClick()"
+        (resetClicked)="onResetClick()" />
 
-    <!-- Current Session Info -->
-    <app-current-session [data]="sessionData()" />
+      <!-- Current Session Info -->
+      <app-current-session [data]="sessionData()" />
 
-    <!-- Daily Summary -->
-    <app-daily-summary [data]="summaryData()" />
+      <!-- Daily Summary -->
+      <app-daily-summary [data]="summaryData()" />
 
-    <!-- Progress Display -->
-    <app-progress-display [data]="progressData()" />
+      <!-- Progress Display -->
+      <app-progress-display [data]="progressData()" />
 
-    <!-- Work Complete Message (shown when daily limit reached) -->
-    <app-work-complete *ngIf="isWorkComplete()" />
+      <!-- Work Complete Message (shown when daily limit reached) -->
+      <app-work-complete *ngIf="isWorkComplete()" />
+    } @else if (currentView() === 'history') {
+      <!-- Work History -->
+      <app-work-history />
+    }
   </div>
 </div>

--- a/src/app/presentation/containers/dashboard/dashboard.container.ts
+++ b/src/app/presentation/containers/dashboard/dashboard.container.ts
@@ -3,7 +3,7 @@
  * @author Work Timer Application
  */
 
-import { Component, inject, computed } from '@angular/core';
+import { Component, inject, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TimerFacade } from '../../../application/facades/timer.facade';
 import { 
@@ -20,6 +20,7 @@ import { CurrentSessionComponent } from '../../components/current-session/curren
 import { DailySummaryComponent } from '../../components/daily-summary/daily-summary.component';
 import { ProgressDisplayComponent } from '../../components/progress-display/progress-display.component';
 import { WorkCompleteComponent } from '../../components/work-complete/work-complete.component';
+import { WorkHistoryComponent } from '../../components/work-history/work-history.component';
 
 /**
  * Smart container component that coordinates all dashboard UI components.
@@ -36,7 +37,8 @@ import { WorkCompleteComponent } from '../../components/work-complete/work-compl
     CurrentSessionComponent,
     DailySummaryComponent,
     ProgressDisplayComponent,
-    WorkCompleteComponent
+    WorkCompleteComponent,
+    WorkHistoryComponent
   ],
   templateUrl: './dashboard.container.html',
   styleUrl: './dashboard.container.css'
@@ -44,6 +46,10 @@ import { WorkCompleteComponent } from '../../components/work-complete/work-compl
 export class DashboardContainer {
   /** Injected timer facade for timer operations */
   private readonly timerFacade = inject(TimerFacade);
+
+  /** Current view signal for switching between timer and history views */
+  private readonly _currentView = signal<'timer' | 'history'>('timer');
+  readonly currentView = computed(() => this._currentView());
 
   /** Computed header data for app header component */
   readonly headerData = computed<HeaderData>(() => ({
@@ -127,5 +133,19 @@ export class DashboardContainer {
     if (status.isRunning()) return 'status-running';
     if (status.isPaused()) return 'status-paused';
     return 'status-stopped';
+  }
+
+  /**
+   * Switches to the timer view.
+   */
+  showTimerView(): void {
+    this._currentView.set('timer');
+  }
+
+  /**
+   * Switches to the work history view.
+   */
+  showHistoryView(): void {
+    this._currentView.set('history');
   }
 }


### PR DESCRIPTION
Implements SQLite persistence for work timer data as requested in issue #2.

## Changes
- Add sql.js dependency for browser-based SQLite database
- Implement SQLite database service with schema creation and migration
- Create SQLite repository implementations for WorkDay, WorkSession, and TimerState
- Add automatic data migration from localStorage to SQLite on app initialization
- Implement app initialization service with loading states and error handling
- Add work history component for viewing and editing past work sessions
- Update dashboard with tab navigation between timer and history views

## Features
- 💾 Persistent storage for all work timer data
- 📊 Historical data viewing and analysis
- ✏️ Edit past work sessions
- 🗑️ Delete individual sessions
- 🔄 Automatic data migration from localStorage

Closes #2

Generated with [Claude Code](https://claude.ai/code)