### PR TITLE
Replace 'any' types with proper TypeScript interfaces

### DIFF
--- a/src/app/application/facades/timer.facade.ts
+++ b/src/app/application/facades/timer.facade.ts
@@ -17,7 +17,7 @@ import { StopWorkCommand } from '../commands/stop-work.command';
 import { ResetTimerCommand } from '../commands/reset-timer.command';
 import { GetCurrentSessionQuery } from '../queries/get-current-session.query';
 import { GetDailyReportQuery } from '../queries/get-daily-report.query';
-import { Duration, TimerStatus, WorkDayDate } from '../../domain';
+import { Duration, TimerStatus, WorkDayDate, DomainEvent, WorkDaySerializationData } from '../../domain';
 
 @Injectable({
   providedIn: 'root'
@@ -135,7 +135,7 @@ export class TimerFacade implements OnDestroy {
   }
 
   private setupEventHandlers(): void {
-    this.timerApplicationService.onEvent((event: any) => {
+    this.timerApplicationService.onEvent((event: DomainEvent) => {
       console.log('Domain event:', event.eventType, event);
       this.updateState();
     });
@@ -192,7 +192,7 @@ export class TimerFacade implements OnDestroy {
     console.log('Saving work day data:', data);
   }
 
-  loadFromStorage(data: any): void {
+  loadFromStorage(data: WorkDaySerializationData): void {
     // This will be implemented when we create the infrastructure layer
     this.timerApplicationService.loadWorkDay(data);
     this.updateState();

--- a/src/app/application/services/timer-application.service.ts
+++ b/src/app/application/services/timer-application.service.ts
@@ -14,7 +14,9 @@ import {
   WorkSessionStartedEvent,
   WorkSessionStoppedEvent,
   PauseDeductionAppliedEvent,
-  DailyLimitReachedEvent 
+  DailyLimitReachedEvent,
+  DomainEvent,
+  WorkDaySerializationData
 } from '../../domain';
 
 export interface TimerApplicationState {
@@ -35,7 +37,7 @@ export interface TimerApplicationState {
 })
 export class TimerApplicationService {
   private _currentWorkDay: WorkDay;
-  private _eventHandlers: Array<(event: any) => void> = [];
+  private _eventHandlers: Array<(event: DomainEvent) => void> = [];
 
   constructor(
     private timeCalculationService: TimeCalculationService,
@@ -128,7 +130,7 @@ export class TimerApplicationService {
     }
   }
 
-  loadWorkDay(workDayData: any): void {
+  loadWorkDay(workDayData: WorkDaySerializationData): void {
     try {
       this._currentWorkDay = WorkDay.fromData(workDayData);
     } catch (error) {
@@ -137,7 +139,7 @@ export class TimerApplicationService {
     }
   }
 
-  getWorkDayData(): any {
+  getWorkDayData(): WorkDaySerializationData {
     return this._currentWorkDay.toData();
   }
 
@@ -179,11 +181,11 @@ export class TimerApplicationService {
     return this._currentWorkDay.status.getDisplayText();
   }
 
-  onEvent(handler: (event: any) => void): void {
+  onEvent(handler: (event: DomainEvent) => void): void {
     this._eventHandlers.push(handler);
   }
 
-  private emitEvent(event: any): void {
+  private emitEvent(event: DomainEvent): void {
     this._eventHandlers.forEach(handler => {
       try {
         handler(event);

--- a/src/app/domain/entities/work-day.ts
+++ b/src/app/domain/entities/work-day.ts
@@ -17,6 +17,22 @@ export interface WorkDayCalculations {
   isComplete: boolean;
 }
 
+export interface WorkSessionData {
+  id: string;
+  startTime: Date;
+  endTime: Date | null;
+  duration: number;
+  date: string;
+}
+
+export interface WorkDaySerializationData {
+  date: string;
+  sessions: WorkSessionData[];
+  currentSession: WorkSessionData | null;
+  status: string;
+  pauseDeductionApplied: boolean;
+}
+
 export class WorkDay {
   private readonly _sessions: WorkSession[] = [];
   private _currentSession: WorkSession | null = null;
@@ -220,13 +236,7 @@ export class WorkDay {
     return this._status.isRunning();
   }
 
-  toData(): {
-    date: string;
-    sessions: any[];
-    currentSession: any | null;
-    status: string;
-    pauseDeductionApplied: boolean;
-  } {
+  toData(): WorkDaySerializationData {
     return {
       date: this.date.toISOString(),
       sessions: this._sessions.map(session => session.toData()),
@@ -236,13 +246,7 @@ export class WorkDay {
     };
   }
 
-  static fromData(data: {
-    date: string;
-    sessions: any[];
-    currentSession: any | null;
-    status: string;
-    pauseDeductionApplied: boolean;
-  }): WorkDay {
+  static fromData(data: WorkDaySerializationData): WorkDay {
     const date = WorkDayDate.fromString(data.date);
     const sessions = data.sessions.map(sessionData => WorkSession.fromData(sessionData));
     const currentSession = data.currentSession ? WorkSession.fromData(data.currentSession) : null;

--- a/src/app/domain/entities/work-session.ts
+++ b/src/app/domain/entities/work-session.ts
@@ -5,6 +5,7 @@
 
 import { Duration } from '../value-objects/duration';
 import { WorkDayDate } from '../value-objects/work-day-date';
+import { WorkSessionData } from './work-day';
 
 export class WorkSession {
   private constructor(
@@ -21,13 +22,7 @@ export class WorkSession {
     return new WorkSession(id, startTime, null, workDate, Duration.zero());
   }
 
-  static fromData(data: { 
-    id: string; 
-    startTime: Date; 
-    endTime: Date | null; 
-    duration: number;
-    date: string;
-  }): WorkSession {
+  static fromData(data: WorkSessionData): WorkSession {
     const workDate = WorkDayDate.fromString(data.date);
     return new WorkSession(
       data.id, 
@@ -70,13 +65,7 @@ export class WorkSession {
     return Duration.fromMilliseconds(currentTime.getTime() - this.startTime.getTime());
   }
 
-  toData(): { 
-    id: string; 
-    startTime: Date; 
-    endTime: Date | null; 
-    duration: number;
-    date: string;
-  } {
+  toData(): WorkSessionData {
     return {
       id: this.id,
       startTime: this.startTime,

--- a/src/app/infrastructure/repositories/http-work-day.repository.ts
+++ b/src/app/infrastructure/repositories/http-work-day.repository.ts
@@ -95,7 +95,7 @@ export class HttpWorkDayRepository implements WorkDayRepository {
   /**
    * Handle HTTP errors and convert to user-friendly messages
    */
-  private handleError(error: any, defaultMessage: string): Error {
+  private handleError(error: unknown, defaultMessage: string): Error {
     if (error instanceof HttpErrorResponse) {
       if (error.status === 0) {
         return new Error('Unable to connect to server. Please ensure the Node.js backend is running.');

--- a/src/app/infrastructure/repositories/http-work-session.repository.ts
+++ b/src/app/infrastructure/repositories/http-work-session.repository.ts
@@ -109,7 +109,7 @@ export class HttpWorkSessionRepository implements WorkSessionRepository {
   /**
    * Handle HTTP errors and convert to user-friendly messages
    */
-  private handleError(error: any, defaultMessage: string): Error {
+  private handleError(error: unknown, defaultMessage: string): Error {
     if (error instanceof HttpErrorResponse) {
       if (error.status === 0) {
         return new Error('Unable to connect to server. Please ensure the Node.js backend is running.');

--- a/src/app/presentation/components/work-history/work-history.component.ts
+++ b/src/app/presentation/components/work-history/work-history.component.ts
@@ -6,7 +6,7 @@
 import { Component, signal, computed, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { WorkSession, WorkDay, WorkDayDate } from '../../../domain/index';
+import { WorkSession, WorkDay, WorkDayDate, Duration } from '../../../domain/index';
 import { WorkDayRepository } from '../../../domain/repositories/work-day.repository';
 import { WorkSessionRepository } from '../../../domain/repositories/work-session.repository';
 import { WORK_DAY_REPOSITORY, WORK_SESSION_REPOSITORY } from '../../../domain/repositories/injection-tokens';
@@ -224,7 +224,7 @@ export class WorkHistoryComponent implements OnInit {
     }
   }
 
-  private calculateEffectiveWorkTime(workDay: WorkDay): any {
+  private calculateEffectiveWorkTime(workDay: WorkDay): Duration {
     const totalWorkTime = workDay.calculateTotalWorkTime();
     // Simplified calculation - in real implementation, apply pause deduction logic
     return totalWorkTime;


### PR DESCRIPTION
- Create WorkSessionData and WorkDaySerializationData interfaces
- Replace all 'any' types in domain entities with specific interfaces
- Update event handling to use DomainEvent interface
- Fix error handling to use 'unknown' type instead of 'any'
- Improve type safety across facades, services, and components

Fixes #7